### PR TITLE
Fix find_by_name bug

### DIFF
--- a/service/models.py
+++ b/service/models.py
@@ -142,4 +142,4 @@ class Account(db.Model, PersistentBase):
             name (string): the name of the Accounts you want to match
         """
         logger.info("Processing name query for %s ...", name)
-        return cls.query.filter(cls.name == name)
+        return cls.query.filter(cls.name == name).all()


### PR DESCRIPTION
## Summary
- return a list of accounts from `find_by_name`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685138657d18832ea19af9f1a781ed93